### PR TITLE
暴露onPaste事件

### DIFF
--- a/src/fileGetter.js
+++ b/src/fileGetter.js
@@ -130,9 +130,14 @@ export default class {
 
     _pasteHandle() {
         if (this.config.paste) {
-            this.eventDelegate.on('paste', this.config.paste, (event) => {
-                let clipboardData = event.clipboardData;
+            this.eventDelegate.on('paste', this.config.paste, async (event) => {
 
+                let res = await this.eventEmitter.emit('onPaste', {event});
+                if (res.indexOf(false) !== -1) {
+                    return void 0;
+                }
+
+                let clipboardData = event.clipboardData;
                 if (!!clipboardData) {
                     let items = clipboardData.items;
                     for (let i = 0; i < items.length; ++i) {
@@ -152,6 +157,7 @@ export default class {
                         this.pushQueue(blob, groupInfo);
                     }
                 }
+
             });
         }
     }


### PR DESCRIPTION
不同环境，chrome、Safari、electron对于粘贴事件获取的数据不同，交给上层自行处理